### PR TITLE
Support AWS instance profile credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ jclouds.provider=filesystem
 jclouds.filesystem.basedir=/tmp/s3proxy
 ```
 
+For deployments on Amazon EC2, S3Proxy can fetch credentials from the
+instance metadata service.  When using the `aws-s3` provider you may omit
+`jclouds.identity` and `jclouds.credential` and enable instance profile
+credentials via:
+
+```
+jclouds.provider=aws-s3
+jclouds.region=us-east-1
+jclouds.aws.use-instance-credentials=true
+```
+
+This uses the AWS default credentials provider chain so that the instance
+profile supplies temporary credentials.
+
 First create the filesystem basedir:
 
 ```

--- a/src/main/java/org/gaul/s3proxy/Main.java
+++ b/src/main/java/org/gaul/s3proxy/Main.java
@@ -359,6 +359,11 @@ public final class Main {
         String identity = properties.getProperty(Constants.PROPERTY_IDENTITY);
         String credential = properties.getProperty(
                 Constants.PROPERTY_CREDENTIAL);
+        String useInstanceCredentialsString = properties.getProperty(
+                "jclouds.aws.use-instance-credentials");
+        boolean useInstanceCredentials = useInstanceCredentialsString != null &&
+                useInstanceCredentialsString.equalsIgnoreCase("true");
+        properties.remove("jclouds.aws.use-instance-credentials");
         String endpoint = properties.getProperty(Constants.PROPERTY_ENDPOINT);
         properties.remove(Constants.PROPERTY_ENDPOINT);
         String region = properties.getProperty(
@@ -387,12 +392,20 @@ public final class Main {
             System.clearProperty(Constants.PROPERTY_CREDENTIAL);
         }
 
-        if (identity == null || credential == null) {
+        boolean missingIdentityOrCredential = identity == null ||
+                credential == null;
+        if (missingIdentityOrCredential && !provider.equals("aws-s3")) {
             System.err.println(
                     "Properties file must contain: " +
                     Constants.PROPERTY_IDENTITY + " and " +
                     Constants.PROPERTY_CREDENTIAL);
             System.exit(1);
+        }
+        if (identity == null) {
+            identity = "";
+        }
+        if (credential == null) {
+            credential = "";
         }
 
         properties.setProperty(Constants.PROPERTY_USER_AGENT,
@@ -411,7 +424,9 @@ public final class Main {
             builder = builder.endpoint(endpoint);
         }
 
-        if ((identity.isEmpty() || credential.isEmpty()) && provider.equals("aws-s3")) {
+        if (provider.equals("aws-s3") &&
+                (useInstanceCredentials || identity.isEmpty() ||
+                        credential.isEmpty())) {
             @SuppressModernizer
             Supplier<Credentials> credentialsSupplier = new Supplier<Credentials>() {
                 @Override

--- a/src/test/java/org/gaul/s3proxy/AwsInstanceProfileCredentialsTest.java
+++ b/src/test/java/org/gaul/s3proxy/AwsInstanceProfileCredentialsTest.java
@@ -1,0 +1,71 @@
+package org.gaul.s3proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.jclouds.Constants;
+import org.junit.Test;
+
+public final class AwsInstanceProfileCredentialsTest {
+    @Test
+    public void testBackendInitializesWithInstanceCredentials() throws Exception {
+        AtomicInteger hits = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/latest/api/token", exchange -> {
+            hits.incrementAndGet();
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.createContext("/latest/meta-data/iam/security-credentials/", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                hits.incrementAndGet();
+                byte[] body = "stub-role".getBytes();
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body);
+                }
+            }
+        });
+        server.createContext("/latest/meta-data/iam/security-credentials/stub-role", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                hits.incrementAndGet();
+                String json = "{\"AccessKeyId\":\"stub\",\"SecretAccessKey\":\"stub\",\"Token\":\"stub\",\"Expiration\":\"2030-01-01T00:00:00Z\"}";
+                byte[] body = json.getBytes();
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body);
+                }
+            }
+        });
+        server.start();
+        String metadataEndpoint = "http://localhost:" + server.getAddress().getPort();
+        System.setProperty("com.amazonaws.sdk.ec2MetadataServiceEndpointOverride", metadataEndpoint);
+
+        Properties props = new Properties();
+        props.setProperty(Constants.PROPERTY_PROVIDER, "aws-s3");
+        props.setProperty("jclouds.aws.use-instance-credentials", "true");
+        props.setProperty(Constants.PROPERTY_ENDPOINT, "http://localhost:1");
+        props.setProperty("jclouds.region", "us-east-1");
+
+        var method = Main.class.getDeclaredMethod("createBlobStore", Properties.class, java.util.concurrent.ExecutorService.class);
+        method.setAccessible(true);
+        var blobStore = method.invoke(null, props, Executors.newSingleThreadExecutor());
+
+        assertThat(blobStore).isNotNull();
+        assertThat(hits.get()).isGreaterThanOrEqualTo(2);
+
+        server.stop(0);
+        System.clearProperty("com.amazonaws.sdk.ec2MetadataServiceEndpointOverride");
+    }
+}


### PR DESCRIPTION
## Summary
- allow aws-s3 backend to omit identity/credential and use instance profile credentials via `jclouds.aws.use-instance-credentials`
- document new option and example configuration
- add regression test covering IMDS-based credentials

## Testing
- `mvn -q -e -Dtest=AwsInstanceProfileCredentialsTest test` *(fails: Non-resolvable parent POM for org.gaul:s3proxy:2.7.1-SNAPSHOT: Could not transfer artifact org.sonatype.oss:oss-parent:pom:7)*

------
https://chatgpt.com/codex/tasks/task_e_68b8159a9d74832f954772b44082c33d